### PR TITLE
add EntityMetaData for XL

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,13 +83,14 @@ func buildProbe(stype, targetConf, topoConf string, stop chan struct{}) (*probe.
 		return nil, fmt.Errorf("failed to load json conf:%v", err.Error())
 	}
 
-	regClient := registration.NewRegistrationClient(stype)
+	regClient := registration.NewRegClient(stype)
 	discoveryClient := discovery.NewDiscoveryClient(config, clusterHandler)
 	actionHandler := action.NewActionHandler(clusterHandler, stop)
 
 	builder := probe.NewProbeBuilder(config.TargetType, config.ProbeCategory).
 		RegisteredBy(regClient).
 		WithActionPolicies(regClient).
+		WithEntityMetadata(regClient).
 		DiscoversTarget(config.Address, discoveryClient).
 		ExecutesActionsBy(actionHandler)
 

--- a/pkg/registration/registration_client_test.go
+++ b/pkg/registration/registration_client_test.go
@@ -30,7 +30,7 @@ func xcheck(expected map[proto.ActionItemDTO_ActionType]proto.ActionPolicyDTO_Ac
 }
 
 func TestK8sRegistrationClient_GetActionPolicy(t *testing.T) {
-	reg := NewRegistrationClient("mock")
+	reg := NewRegClient("mock")
 
 	supported := proto.ActionPolicyDTO_SUPPORTED
 	recommend := proto.ActionPolicyDTO_NOT_EXECUTABLE


### PR DESCRIPTION
**Problem**
When adding this target to XL appliance, there is error:
```terminal
topology-processor-1: 2018-05-24 18:25:45,277 ERROR [pool-8-thread-1] [OperationManager]	: Error processing discovery response:
rsyslog_1              | topology-processor-1: com.vmturbo.topology.processor.identity.IdentityMetadataMissingException: Probe 72467174512624 sends entities of type PHYSICAL_MACHINE but provides no related identity metadata.
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.identity.IdentityProviderImpl.getIdsForEntities(IdentityProviderImpl.java:203)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.entity.EntityStore.assignIdsToEntities(EntityStore.java:256)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.entity.EntityStore.entitiesDiscovered(EntityStore.java:292)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.operation.OperationManager.processDiscoveryResponse(OperationManager.java:645)
rsyslog_1              | topology-processor-1: 	at com.vmturbo.topology.processor.operation.OperationManager.lambda$notifyDiscoveryResult$9(OperationManager.java:486)
rsyslog_1              | topology-processor-1: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
rsyslog_1              | topology-processor-1: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
rsyslog_1              | topology-processor-1: 	at java.lang.Thread.run(Thread.java:748)
```

**Fix**
(1) add `GetEntityMetadata` when registrate the probe.
(2) Fix the bug about `pb.entityMetadataProvider` in [turbo-go-sdk](https://github.com/turbonomic/turbo-go-sdk/blob/771c5767564845eda68aa5e8a545c6810f85d0ea/pkg/probe/probe_builder.go#L104)
```golang
  if pb.entityMetadataProvider != nil {
             turboProbe.RegistrationClient.IEntityMetadataProvider = pb.entityMetadataProvider
   }
```
